### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/supabase/functions/event-rejection-email/index.ts
+++ b/supabase/functions/event-rejection-email/index.ts
@@ -84,8 +84,8 @@ Deno.serve(async req => {
       { headers: { 'Content-Type': 'application/json' } }
     );
   } catch (error) {
-    console.error('Error:', error);
-    return new Response(JSON.stringify({ error }), {
+    console.error('Error:', error); // Log the full error details on the server
+    return new Response(JSON.stringify({ message: "An internal server error occurred" }), {
       headers: { 'Content-Type': 'application/json' },
       status: 500,
     });


### PR DESCRIPTION
Potential fix for [https://github.com/founder-srm/Founders-website/security/code-scanning/2](https://github.com/founder-srm/Founders-website/security/code-scanning/2)

To fix the issue, we should avoid exposing the raw `error` object to the client. Instead, we can log the full error details (including the stack trace) on the server for debugging purposes and return a generic error message to the client. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues.

Specifically:
1. Replace `JSON.stringify({ error })` with a generic error message like `JSON.stringify({ message: "An internal server error occurred" })`.
2. Log the full `error` object (including the stack trace) to the server console using `console.error`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
