### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/supabase/functions/contact-function/index.ts
+++ b/supabase/functions/contact-function/index.ts
@@ -64,7 +64,7 @@ Deno.serve(async req => {
     );
   } catch (error) {
     console.error('Error:', error);
-    return new Response(JSON.stringify({ error }), {
+    return new Response(JSON.stringify({ message: "An internal server error occurred." }), {
       headers: { 'Content-Type': 'application/json' },
       status: 500,
     });


### PR DESCRIPTION
Potential fix for [https://github.com/founder-srm/Founders-website/security/code-scanning/1](https://github.com/founder-srm/Founders-website/security/code-scanning/1)

To fix this issue, never include the raw `error` object in the HTTP response sent to the user. Instead, return only a generic error message (such as `"Internal server error"` or `"An exception occurred"`). If you want to retain information for debugging, log the error object (including the stack trace) server-side using `console.error`. Specifically in the supplied code, on line 67, replace `return new Response(JSON.stringify({ error }) ...)` with `return new Response(JSON.stringify({ message: "An internal server error occurred." }) ...)`. The error object should still be logged internally for developer reference.

Thus, in `supabase/functions/contact-function/index.ts`, lines in the catch block corresponding to the HTTP response should be replaced to remove the use of the raw error object.

No external libraries are needed; only minor code changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
