### PR TITLE
[HACKTOBERFEST] Fix: Client-side sorting of upcoming events to descending date for #85

### DIFF
--- a/src/app/(home)/upcoming/page.tsx
+++ b/src/app/(home)/upcoming/page.tsx
@@ -26,7 +26,9 @@ export default function Upcoming() {
       return [];
     }
 
-    setEvents(events as eventsInsertType[]);
+      const sorted = (events as eventsInsertType[]).sort((a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime());
+      setEvents(sorted);
+
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR fixes **Issue #85**, resolving a bug where the Upcoming Events page displayed events in ascending order by default, causing older events to appear above newer ones.

###  Before Fix:
<img width="1353" height="943" alt="Screenshot 2025-10-02 at 23 04 27" src="https://github.com/user-attachments/assets/f726ba8c-c847-42b9-a7c1-56a3dd4358dd" />


### Changes Made:

* Implemented **client-side sorting** of the events array based on the event start date (newest first).
* Updated `src/app/(home)/upcoming/page.tsx` to sort the fetched events before setting state, using the following logic:

    ```javascript
    const sorted = [...(events as eventsInsertType[])].sort(
      (a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime()
    );
    setEvents(sorted);
    ```

* **No backend / Supabase query changes required.**
* Ensures `FeaturedPost` and `UpcomingGrid` now correctly display the most recent events at the top.

###  After Fix:
<img width="809" height="581" alt="Screenshot 2025-10-02 at 23 06 48" src="https://github.com/user-attachments/assets/e4f1140a-0752-49e2-943c-aaadfdfeb1fc" />

### Result:

* Default view shows **newest events first**.
* Event ordering is now based on actual event dates, not record creation time.

---

##  PR Summary


* **Fixed default sorting** of Upcoming Events.
* Events now display **newest first** based on their start date.
* Implemented client-side array sorting in `src/app/(home)/upcoming/page.tsx`.
* **Before:** Oldest events appeared first.
* **After:** Newest events appear first.

